### PR TITLE
fix: divide not multiply

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -16,24 +16,22 @@ const app = new Vue({
             }
         },
         totalTaxes() {
-            let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
-            let result = totalTaxes;
+            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
             
-            return result.toFixed(2);
+            return totalWithTaxes.toFixed(2);
         },
         totalTip() {
-            let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
-            let totalTip = ((this.tip * this.dinner) / 100) + this.dinner;
-            let result = totalTaxes + totalTip;
+            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
+            const totalWithTip = totalWithTaxes * this.tip;
             
-            return result.toFixed(2);
+            return totalWithTip.toFixed(2);
         },
         totalPerson() {
-            let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
-            let totalTip = ((this.tip * this.dinner) / 100) + this.dinner;
-            let result = (totalTaxes + totalTip) / this.people;
+            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
+            const totalWithTip = totalWithTaxes * this.tip;
+            let perPerson = totalWithTip / this.people;
             
-            return result.toFixed(2);
+            return perPerson.toFixed(2);
         }
     },
 });

--- a/js/app.js
+++ b/js/app.js
@@ -11,25 +11,28 @@ const app = new Vue({
             this[key]++;
         },
         decrement(key) {
-            if(this[key] > 1 ) {
+            if (this[key] > 1 ) {
                 this[key]--; 
             }
         },
         totalTaxes() {
             let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
             let result = totalTaxes;
+            
             return result.toFixed(2);
         },
         totalTip() {
             let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
             let totalTip = ((this.tip * this.dinner) / 100) + this.dinner;
             let result = totalTaxes + totalTip;
+            
             return result.toFixed(2);
         },
         totalPerson() {
             let totalTaxes = ((this.taxes * this.dinner) / 100) + this.dinner;
             let totalTip = ((this.tip * this.dinner) / 100) + this.dinner;
-            let result = (totalTaxes + totalTip) * this.people;
+            let result = (totalTaxes + totalTip) / this.people;
+            
             return result.toFixed(2);
         }
     },

--- a/js/app.js
+++ b/js/app.js
@@ -16,20 +16,17 @@ const app = new Vue({
             }
         },
         totalTaxes() {
-            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
+            const totalWithTaxes = this.dinner * (1 + this.taxes);
             
             return totalWithTaxes.toFixed(2);
         },
         totalTip() {
-            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
-            const totalWithTip = totalWithTaxes * this.tip;
+            const totalWithTip = this.totalTaxes() * (1 + this.tip);
             
             return totalWithTip.toFixed(2);
         },
         totalPerson() {
-            const totalWithTaxes = (this.taxes * this.dinner) / 100) + this.dinner;
-            const totalWithTip = totalWithTaxes * this.tip;
-            let perPerson = totalWithTip / this.people;
+            const perPerson = this.totalTip() / this.people;
             
             return perPerson.toFixed(2);
         }


### PR DESCRIPTION
There is a formula error.

The cost per person ends up being way too much - divide by number of people so that each additional person pays less.

I'm assuming `Dinner` is the cost for the _entire_ meal at the bottom of your bill.

Because 5 people aren't going to each have 100 Euro as their exact cost.